### PR TITLE
ID-5076: Java 17

### DIFF
--- a/.github/workflows/call-maventests.yml
+++ b/.github/workflows/call-maventests.yml
@@ -11,5 +11,5 @@ jobs:
   call-workflow-maven-build:
     uses: felleslosninger/github-workflows/.github/workflows/ci-maven-build-lib.yml@main
     with:
-      java-version: 11
+      java-version: 17
     secrets: inherit

--- a/.github/workflows/call-release.yml
+++ b/.github/workflows/call-release.yml
@@ -11,7 +11,7 @@ jobs:
   call-workflow-maven-deploy:
     uses: felleslosninger/github-workflows/.github/workflows/ci-maven-deploy.yml@main
     with:
-      java-version: 11
+      java-version: 17
       package-version: ${{ github.event.release.tag_name }}
       deployment-repository: ${{ github.repository }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# idporten-generate-fnr
+# idporten-fnr-generate
 
-![Maven build status](https://github.com/felleslosninger/idporten-generate-fnr/actions/workflows/call-maventests.yml/badge.svg)
-[![Latest Stable Version](https://img.shields.io/github/v/release/felleslosninger/idporten-generate-fnr?display_name=tag)](https://github.com/felleslosninger/idporten-generate-fnr/releases)
+![Maven build status](https://github.com/felleslosninger/idporten-fnr-generate/actions/workflows/call-maventests.yml/badge.svg)
+[![Latest Stable Version](https://img.shields.io/github/v/release/felleslosninger/idporten-fnr-generate?display_name=tag)](https://github.com/felleslosninger/idporten-fnr-generate/releases)
 
 Generate random syntetic personidentfiers (fodselsnummer) for Norway.
 https://www.skatteetaten.no/person/folkeregister/fodsel-og-navnevalg/barn-fodt-i-norge/fodselsnummer/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://www.skatteetaten.no/person/folkeregister/fodsel-og-navnevalg/barn-fodt-i
 ## Requirements
 To build and run the library you need:
 
-* Java 11
+* Java 17
 * Maven
 
 ## Running the library locally
@@ -27,7 +27,7 @@ Include in pom.xml
         <dependency>
             <groupId>no.idporten.test.generate</groupId>
             <artifactId>idporten-fnr-generate</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <idporten-validators-version>0.1.1</idporten-validators-version>
         <junit-jupiter-version>5.9.3</junit-jupiter-version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <slf4j.version>2.0.7</slf4j.version>
     </properties>
 


### PR DESCRIPTION
Old dependabot PRs fails maven build on 401 (forbidden) on download validator-lib, Bjørn-E and I have not figured out why, so have to just merge them into this one to get them out.

Upgraded dependencies:
* junit-jupiter-version from 5.9.3 to 5.11.4
* org.slf4j:slf4j-api from 2.0.7 to 2.0.16
* no.idporten.validators:idporten-validators from 0.1.1 to 1.4.2